### PR TITLE
use libsecp256k1 library from electron cash

### DIFF
--- a/electrum-wallet3/bitcoincash.yml
+++ b/electrum-wallet3/bitcoincash.yml
@@ -13,6 +13,7 @@
   roles:
     - devel
     - python3
+    - libsecp256k1
     - electrum-wallet
   tasks:
     - name: systemd template setup


### PR DESCRIPTION
use libsecp256k1 library from electron cash to deal with this warning

```
|  0.004| [ecc] info: libsecp256k1 library not available, falling back to python-ecdsa. This means signing operations will be slower.
```